### PR TITLE
Add Xcode 12.5 support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,3 +27,9 @@ alias(
     actual = "//Sources/XCBProtocol_12_0",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "XCBProtocol_12_5",
+    actual = "//Sources/XCBProtocol_12_5",
+    visibility = ["//visibility:public"],
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
     name: "BazelXCBBuildServiceProxy",
-    platforms: [.macOS(.v10_14)],
+    platforms: [.macOS(.v10_15)],
     products: [
         .library(name: "XCBProtocol", targets: ["XCBProtocol"]),
         .library(name: "XCBProtocol_11_3", targets: ["XCBProtocol_11_3"]),
@@ -18,48 +18,59 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "MessagePack"
+            name: "MessagePack",
+            exclude: [
+                "BUILD.bazel",
+                "LICENSE",
+                "README.md"
+            ]
         ),
         .testTarget(
             name: "MessagePackTests",
-            dependencies: ["MessagePack"]
+            dependencies: ["MessagePack"],
+            exclude: ["BUILD.bazel"]
         ),
         .target(
             name: "XCBProtocol",
             dependencies: [
-                "Logging",
                 "MessagePack",
-                "NIO",
-            ]
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
+            ],
+            exclude: ["BUILD.bazel"]
         ),
         .target(
             name: "XCBProtocol_11_3",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ]
+            ],
+            exclude: ["BUILD.bazel"]
         ),
         .target(
             name: "XCBProtocol_11_4",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ]
+            ],
+            exclude: ["BUILD.bazel"]
         ),
         .target(
             name: "XCBProtocol_12_0",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ]
+            ],
+            exclude: ["BUILD.bazel"]
         ),
         .target(
             name: "XCBBuildServiceProxy",
             dependencies: [
-                "Logging",
-                "NIO",
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
                 "XCBProtocol",
-            ]
+            ],
+            exclude: ["BUILD.bazel"]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
     name: "BazelXCBBuildServiceProxy",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v10_14)],
     products: [
         .library(name: "XCBProtocol", targets: ["XCBProtocol"]),
         .library(name: "XCBProtocol_11_3", targets: ["XCBProtocol_11_3"]),
@@ -19,50 +19,40 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "MessagePack",
-            exclude: [
-                "BUILD.bazel",
-                "LICENSE",
-                "README.md"
-            ]
+            name: "MessagePack"
         ),
         .testTarget(
             name: "MessagePackTests",
-            dependencies: ["MessagePack"],
-            exclude: ["BUILD.bazel"]
+            dependencies: ["MessagePack"]
         ),
         .target(
             name: "XCBProtocol",
             dependencies: [
+                "Logging",
                 "MessagePack",
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio"),
-            ],
-            exclude: ["BUILD.bazel"]
+                "NIO",
+            ]
         ),
         .target(
             name: "XCBProtocol_11_3",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ],
-            exclude: ["BUILD.bazel"]
+            ]
         ),
         .target(
             name: "XCBProtocol_11_4",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ],
-            exclude: ["BUILD.bazel"]
+            ]
         ),
         .target(
             name: "XCBProtocol_12_0",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ],
-            exclude: ["BUILD.bazel"]
+            ]
         ),
         .target(
             name: "XCBProtocol_12_5",
@@ -75,11 +65,10 @@ let package = Package(
         .target(
             name: "XCBBuildServiceProxy",
             dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio"),
+                "Logging",
+                "NIO",
                 "XCBProtocol",
-            ],
-            exclude: ["BUILD.bazel"]
+            ]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .library(name: "XCBProtocol_11_3", targets: ["XCBProtocol_11_3"]),
         .library(name: "XCBProtocol_11_4", targets: ["XCBProtocol_11_4"]),
         .library(name: "XCBProtocol_12_0", targets: ["XCBProtocol_12_0"]),
+        .library(name: "XCBProtocol_12_5", targets: ["XCBProtocol_12_5"]),
         .library(name: "XCBBuildServiceProxy", targets: ["XCBBuildServiceProxy"]),
     ],
     dependencies: [
@@ -57,6 +58,14 @@ let package = Package(
         ),
         .target(
             name: "XCBProtocol_12_0",
+            dependencies: [
+                "MessagePack",
+                "XCBProtocol",
+            ],
+            exclude: ["BUILD.bazel"]
+        ),
+        .target(
+            name: "XCBProtocol_12_5",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",

--- a/Package.swift
+++ b/Package.swift
@@ -59,8 +59,7 @@ let package = Package(
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",
-            ],
-            exclude: ["BUILD.bazel"]
+            ]
         ),
         .target(
             name: "XCBBuildServiceProxy",

--- a/Sources/XCBProtocol_12_5/BUILD.bazel
+++ b/Sources/XCBProtocol_12_5/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "XCBProtocol_12_5",
+    srcs = glob(["**/*.swift"]),
+    module_name = "XCBProtocol_12_5",
+    deps = [
+        "//Sources/MessagePack",
+        "//Sources/XCBProtocol",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationEnded.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationEnded.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationEnded.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationPreparationCompleted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationPreparationCompleted.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationPreparationCompleted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationProgressUpdated.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationProgressUpdated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationProgressUpdated.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationReportPathMap.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationReportPathMap.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationReportPathMap.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationStarted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationStarted.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationStarted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/BuildOperationStatus.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/BuildOperationStatus.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationStatus.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_12_0/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetEnded.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetEnded.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetEnded.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetInfo.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetInfo.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetInfo.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetProjectInfo.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetProjectInfo.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetProjectInfo.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetStarted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetStarted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetStarted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetUpToDate.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Target/BuildOperationTargetUpToDate.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetUpToDate.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskEnded.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskEnded.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskEnded.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskMetrics.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskMetrics.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskMetrics.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskStarted.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskStarted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskStarted.swift

--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskUpToDate.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskUpToDate.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskUpToDate.swift

--- a/Sources/XCBProtocol_12_5/Build/ArenaInfo.swift
+++ b/Sources/XCBProtocol_12_5/Build/ArenaInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/ArenaInfo.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildCancelRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildCancelRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildCancelRequest.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildCommand.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildCommand.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildCommand.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildCreated.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildCreated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildCreated.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildParameters.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildParameters.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildParameters.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildPlatform.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildPlatform.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildPlatform.swift

--- a/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
@@ -37,7 +37,7 @@ extension BuildRequest: DecodableRPCPayload {
         self.configuredTargets = try targetGUIDsArray.enumerated().map { index, _ in
             try targetGUIDsArray.parseObject(indexPath: targetsIndexPath + IndexPath(index: index))
         }
-        
+
         self.continueBuildingAfterErrors = try args.parseBool(indexPath: indexPath + IndexPath(index: 2))
         self.hideShellScriptEnvironment = try args.parseBool(indexPath: indexPath + IndexPath(index: 3))
         self.useParallelTargets = try args.parseBool(indexPath: indexPath + IndexPath(index: 4))
@@ -55,9 +55,12 @@ extension BuildRequest: DecodableRPCPayload {
         self.useLegacyBuildLocations = try args.parseBool(indexPath: indexPath + IndexPath(index: 16))
         self.shouldCollectMetrics = try args.parseBool(indexPath: indexPath + IndexPath(index: 17))
 
-        if let jsonRepresentationBase64String = try args.parseOptionalString(indexPath: indexPath + IndexPath(index: 18)),
-           let jsonRepresentationBase64Data = Data(base64Encoded: jsonRepresentationBase64String) {
-            self.jsonRepresentation = String(data: jsonRepresentationBase64Data, encoding: .utf8)
+        if let jsonRepresentationBase64String = try args.parseOptionalString(indexPath: indexPath + IndexPath(index: 18)) {
+            guard let base64Data = Data(base64Encoded: jsonRepresentationBase64String),
+                  let decodedString = String(data: base64Data, encoding: .utf8) else {
+                throw MessagePackUnpackError.invalidData
+            }
+            self.jsonRepresentation = decodedString
         } else {
             self.jsonRepresentation = nil
         }

--- a/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
@@ -18,7 +18,7 @@ public struct BuildRequest {
     public let buildOnlyTheseTargets: MessagePackValue
     public let buildDescriptionID: MessagePackValue
     public let enableIndexBuildArena: Bool
-    public let unknown: MessagePackValue? // comes back as `nil`, so it's unclear what this is or what type it is
+    public let unknown: MessagePackValue // comes back as `.nil`, so it's unclear what this is or what type it is
     public let useLegacyBuildLocations: Bool
     public let shouldCollectMetrics: Bool
     public let jsonRepresentation: String?

--- a/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildRequest.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MessagePack
+import XCBProtocol
+
+public struct BuildRequest {
+    public let parameters: BuildParameters
+    public let configuredTargets: [ConfiguredTarget]
+    public let continueBuildingAfterErrors: Bool
+    public let hideShellScriptEnvironment: Bool
+    public let useParallelTargets: Bool
+    public let useImplicitDependencies: Bool
+    public let useDryRun: Bool
+    public let showNonLoggedProgress: Bool
+    public let buildPlanDiagnosticsDirPath: String?
+    public let buildCommand: BuildCommand
+    public let schemeCommand: SchemeCommand
+    public let buildOnlyTheseFiles: MessagePackValue
+    public let buildOnlyTheseTargets: MessagePackValue
+    public let buildDescriptionID: MessagePackValue
+    public let enableIndexBuildArena: Bool
+    public let unknown1: MessagePackValue? // comes back as `nil`, so it's unclear what this is or what type it is
+    public let useLegacyBuildLocations: Bool
+    public let shouldCollectMetrics: Bool
+    public let unknown2: String? // an encrypted string, possibly `jsonRepresentation`
+}
+
+// MARK: - Decoding
+
+extension BuildRequest: DecodableRPCPayload {
+    public init(args: [MessagePackValue], indexPath: IndexPath) throws {
+        guard args.count == 19 else { throw RPCPayloadDecodingError.invalidCount(args.count, indexPath: indexPath) }
+        
+        self.parameters = try args.parseObject(indexPath: indexPath + IndexPath(index: 0))
+        
+        let targetsIndexPath = indexPath + IndexPath(index: 1)
+        let targetGUIDsArray = try args.parseArray(indexPath: targetsIndexPath)
+        self.configuredTargets = try targetGUIDsArray.enumerated().map { index, _ in
+            try targetGUIDsArray.parseObject(indexPath: targetsIndexPath + IndexPath(index: index))
+        }
+        
+        self.continueBuildingAfterErrors = try args.parseBool(indexPath: indexPath + IndexPath(index: 2))
+        self.hideShellScriptEnvironment = try args.parseBool(indexPath: indexPath + IndexPath(index: 3))
+        self.useParallelTargets = try args.parseBool(indexPath: indexPath + IndexPath(index: 4))
+        self.useImplicitDependencies = try args.parseBool(indexPath: indexPath + IndexPath(index: 5))
+        self.useDryRun = try args.parseBool(indexPath: indexPath + IndexPath(index: 6))
+        self.showNonLoggedProgress = try args.parseBool(indexPath: indexPath + IndexPath(index: 7))
+        self.buildPlanDiagnosticsDirPath = try args.parseOptionalString(indexPath: indexPath + IndexPath(index: 8))
+        self.buildCommand = try args.parseObject(indexPath: indexPath + IndexPath(index: 9))
+        self.schemeCommand = try args.parseObject(indexPath: indexPath + IndexPath(index: 10))
+        self.buildOnlyTheseFiles = try args.parseUnknown(indexPath: indexPath + IndexPath(index: 11))
+        self.buildOnlyTheseTargets = try args.parseUnknown(indexPath: indexPath + IndexPath(index: 12))
+        self.buildDescriptionID = try args.parseUnknown(indexPath: indexPath + IndexPath(index: 13))
+        self.enableIndexBuildArena = try args.parseBool(indexPath: indexPath + IndexPath(index: 14))
+        self.unknown1 = try args.parseUnknown(indexPath: indexPath + IndexPath(index: 15))
+        self.useLegacyBuildLocations = try args.parseBool(indexPath: indexPath + IndexPath(index: 16))
+        self.shouldCollectMetrics = try args.parseBool(indexPath: indexPath + IndexPath(index: 17))
+        self.unknown2 = try args.parseOptionalString(indexPath: indexPath + IndexPath(index: 18))
+    }
+}

--- a/Sources/XCBProtocol_12_5/Build/BuildStartRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/BuildStartRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildStartRequest.swift

--- a/Sources/XCBProtocol_12_5/Build/ConfiguredTarget.swift
+++ b/Sources/XCBProtocol_12_5/Build/ConfiguredTarget.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/ConfiguredTarget.swift

--- a/Sources/XCBProtocol_12_5/Build/CreateBuildRequest.swift
+++ b/Sources/XCBProtocol_12_5/Build/CreateBuildRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_12_0/Build/CreateBuildRequest.swift

--- a/Sources/XCBProtocol_12_5/Build/RunDestinationInfo.swift
+++ b/Sources/XCBProtocol_12_5/Build/RunDestinationInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/RunDestinationInfo.swift

--- a/Sources/XCBProtocol_12_5/Build/SDKVariant.swift
+++ b/Sources/XCBProtocol_12_5/Build/SDKVariant.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/SDKVariant.swift

--- a/Sources/XCBProtocol_12_5/Build/SchemeCommand.swift
+++ b/Sources/XCBProtocol_12_5/Build/SchemeCommand.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/SchemeCommand.swift

--- a/Sources/XCBProtocol_12_5/Build/SettingsOverrides.swift
+++ b/Sources/XCBProtocol_12_5/Build/SettingsOverrides.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/SettingsOverrides.swift

--- a/Sources/XCBProtocol_12_5/Core/BoolResponse.swift
+++ b/Sources/XCBProtocol_12_5/Core/BoolResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/BoolResponse.swift

--- a/Sources/XCBProtocol_12_5/Core/ErrorResponse.swift
+++ b/Sources/XCBProtocol_12_5/Core/ErrorResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/ErrorResponse.swift

--- a/Sources/XCBProtocol_12_5/Core/PingResponse.swift
+++ b/Sources/XCBProtocol_12_5/Core/PingResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/PingResponse.swift

--- a/Sources/XCBProtocol_12_5/Core/StringResponse.swift
+++ b/Sources/XCBProtocol_12_5/Core/StringResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/StringResponse.swift

--- a/Sources/XCBProtocol_12_5/Indexing Info/IndexingInfoRequest.swift
+++ b/Sources/XCBProtocol_12_5/Indexing Info/IndexingInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_12_0/Indexing Info/IndexingInfoRequest.swift

--- a/Sources/XCBProtocol_12_5/Indexing Info/IndexingInfoResponse.swift
+++ b/Sources/XCBProtocol_12_5/Indexing Info/IndexingInfoResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Indexing Info/IndexingInfoResponse.swift

--- a/Sources/XCBProtocol_12_5/Planning Operation/PlanningOperationDidFinish.swift
+++ b/Sources/XCBProtocol_12_5/Planning Operation/PlanningOperationDidFinish.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Planning Operation/PlanningOperationDidFinish.swift

--- a/Sources/XCBProtocol_12_5/Planning Operation/PlanningOperationWillStart.swift
+++ b/Sources/XCBProtocol_12_5/Planning Operation/PlanningOperationWillStart.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Planning Operation/PlanningOperationWillStart.swift

--- a/Sources/XCBProtocol_12_5/Preview Info/PreviewInfo.swift
+++ b/Sources/XCBProtocol_12_5/Preview Info/PreviewInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Preview Info/PreviewInfo.swift

--- a/Sources/XCBProtocol_12_5/Preview Info/PreviewInfoRequest.swift
+++ b/Sources/XCBProtocol_12_5/Preview Info/PreviewInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Preview Info/PreviewInfoRequest.swift

--- a/Sources/XCBProtocol_12_5/Preview Info/PreviewInfoResponse.swift
+++ b/Sources/XCBProtocol_12_5/Preview Info/PreviewInfoResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Preview Info/PreviewInfoResponse.swift

--- a/Sources/XCBProtocol_12_5/RequestPayload.swift
+++ b/Sources/XCBProtocol_12_5/RequestPayload.swift
@@ -1,0 +1,1 @@
+../XCBProtocol_11_4/RequestPayload.swift

--- a/Sources/XCBProtocol_12_5/ResponsePayload.swift
+++ b/Sources/XCBProtocol_12_5/ResponsePayload.swift
@@ -1,0 +1,1 @@
+../XCBProtocol_12_0/ResponsePayload.swift

--- a/Sources/XCBProtocol_12_5/Session/CreateSessionRequest.swift
+++ b/Sources/XCBProtocol_12_5/Session/CreateSessionRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/CreateSessionRequest.swift

--- a/Sources/XCBProtocol_12_5/Session/SessionCreated.swift
+++ b/Sources/XCBProtocol_12_5/Session/SessionCreated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_12_0/Session/SessionCreated.swift

--- a/Sources/XCBProtocol_12_5/Session/SetSessionSystemInfoRequest.swift
+++ b/Sources/XCBProtocol_12_5/Session/SetSessionSystemInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/SetSessionSystemInfoRequest.swift

--- a/Sources/XCBProtocol_12_5/Session/SetSessionUserInfoRequest.swift
+++ b/Sources/XCBProtocol_12_5/Session/SetSessionUserInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/SetSessionUserInfoRequest.swift

--- a/Sources/XCBProtocol_12_5/Session/TransferSessionPIFRequest.swift
+++ b/Sources/XCBProtocol_12_5/Session/TransferSessionPIFRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/TransferSessionPIFRequest.swift


### PR DESCRIPTION
The XCBBuildService communication changed in Xcode 12.5, which required changes to this library to support.

I've tested these changes on our internal project, and they are working fine as far as I can tell.

Big thanks to @brentleyjones for the guidance on how to do this!