### PR TITLE
Another update for Xcode 12.5 support

### DIFF
--- a/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskUpToDate.swift
+++ b/Sources/XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskUpToDate.swift
@@ -1,1 +1,39 @@
-../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskUpToDate.swift
+import Foundation
+import MessagePack
+import XCBProtocol
+
+public struct BuildOperationTaskUpToDate {
+    public let taskGUID: Data
+    public let targetID: Int64?
+    public let unknown: MessagePackValue
+}
+
+// MARK: - ResponsePayloadConvertible
+
+extension BuildOperationTaskUpToDate: ResponsePayloadConvertible {
+    public func toResponsePayload() -> ResponsePayload { .buildOperationTaskUpToDate(self) }
+}
+
+// MARK: - Decoding
+
+extension BuildOperationTaskUpToDate: DecodableRPCPayload {
+    public init(args: [MessagePackValue], indexPath: IndexPath) throws {
+        guard args.count == 3 else { throw RPCPayloadDecodingError.invalidCount(args.count, indexPath: indexPath) }
+        
+        self.taskGUID = try args.parseBinary(indexPath: indexPath + IndexPath(index: 0))
+        self.targetID = try args.parseOptionalInt64(indexPath: indexPath + IndexPath(index: 1))
+        self.unknown = try args.parseUnknown(indexPath: indexPath + IndexPath(index: 2))
+    }
+}
+
+// MARK: - Encoding
+
+extension BuildOperationTaskUpToDate: EncodableRPCPayload {
+    public func encode() -> [MessagePackValue] {
+        return [
+            .binary(taskGUID),
+            targetID.flatMap { .int64($0) } ?? .nil,
+            unknown,
+        ]
+    }
+}


### PR DESCRIPTION
Through some more debugging, I found that the `BuildOperationTaskUpToDate` message needed to also be updated to support Xcode 12.5's new comm format.