### PR TITLE
Change Swift NIO version in Package.swift to 2.30.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Make sure to update the versions used in the `repositories.bzl` file if you change them here
         .package(url: "https://github.com/apple/swift-log", .exact("1.4.2")),
-        .package(url: "https://github.com/apple/swift-nio", .exact("2.30.2")),
+        .package(url: "https://github.com/apple/swift-nio", .exact("2.30.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Correcting a mistake from the last PR. `2.30.2` is not an actual version of Swift NIO.