### PR TITLE
Xcode 13: New BuildOperationDiagnosticLocation type

### DIFF
--- a/Sources/XCBProtocol_13_0/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
+++ b/Sources/XCBProtocol_13_0/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
@@ -1,1 +1,70 @@
-../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
+import Foundation
+import MessagePack
+import XCBProtocol
+
+// Probably named wrong
+public enum BuildOperationDiagnosticLocation {
+    case alternativeMessage(String) // Might be named wrong. Always empty so far.
+    case locationContext(file: String, line: Int64, column: Int64)
+    case target([String])
+}
+
+// MARK: - Decoding
+
+extension BuildOperationDiagnosticLocation: DecodableRPCPayload {
+    public init(args: [MessagePackValue], indexPath: IndexPath) throws {
+        guard args.count == 2 else { throw RPCPayloadDecodingError.invalidCount(args.count, indexPath: indexPath) }
+        
+        let rawValue = try args.parseInt64(indexPath: indexPath + IndexPath(index: 0))
+        
+        switch rawValue {
+        case 0:
+            self = .alternativeMessage(try args.parseString(indexPath: indexPath + IndexPath(index: 1)))
+            
+        case 1:
+            let locationArgs = try args.parseArray(indexPath: indexPath + IndexPath(index: 1))
+            
+            self = .locationContext(
+                file: try locationArgs.parseString(indexPath: indexPath + IndexPath(indexes: [1, 0])),
+                line: try locationArgs.parseInt64(indexPath: indexPath + IndexPath(indexes: [1, 1])),
+                column: try locationArgs.parseInt64(indexPath: indexPath + IndexPath(indexes: [1, 2]))
+            )
+            
+        case 2:
+            let targetArgs = try args.parseArray(indexPath: indexPath + IndexPath(index: 1))
+            self = .target(try targetArgs.parseStringArray(indexPath: indexPath + IndexPath(indexes: [1, 0])))
+            
+        default:
+            throw RPCPayloadDecodingError.incorrectValueType(indexPath: indexPath + IndexPath(index: 0), expectedType: Self.self)
+        }
+    }
+}
+
+// MARK: - Encoding
+
+extension BuildOperationDiagnosticLocation: EncodableRPCPayload {
+    public func encode() -> [MessagePackValue] {
+        switch self {
+        case let .alternativeMessage(message):
+            return [
+                .int64(0),
+                .string(message),
+            ]
+            
+        case let .locationContext(file, line, column):
+            return [
+                .int64(1),
+                .array([
+                    .string(file),
+                    .int64(line),
+                    .int64(column),
+                ]),
+            ]
+            
+        case let .target(names):
+            return [
+                .array(names.map { .string($0) })
+            ]
+        }
+    }
+}

--- a/Sources/XCBProtocol_13_0/Indexing Info/IndexingInfoRequest.swift
+++ b/Sources/XCBProtocol_13_0/Indexing Info/IndexingInfoRequest.swift
@@ -7,7 +7,7 @@ public struct IndexingInfoRequest: Decodable {
     public let responseChannel: UInt64
     public let buildRequest: BuildRequest
     public let targetGUID: String
-    public let filePath: String
+    public let filePath: String?
     public let outputPathOnly: Bool
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
From using Xcode 13 more, I found a new `BuildOperationDiagnosticLocation` type (2 - target), and saw that sometimes the `filePath` is nil in an `IndexingInfoRequest`.