### PR TITLE
Xcode 13: Make IndexingInfoRequest.filePath optional

### DIFF
--- a/Sources/XCBProtocol_13_0/Indexing Info/IndexingInfoRequest.swift
+++ b/Sources/XCBProtocol_13_0/Indexing Info/IndexingInfoRequest.swift
@@ -7,7 +7,7 @@ public struct IndexingInfoRequest: Decodable {
     public let responseChannel: UInt64
     public let buildRequest: BuildRequest
     public let targetGUID: String
-    public let filePath: String
+    public let filePath: String?
     public let outputPathOnly: Bool
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
Sometimes it's optional in Xcode 13!