### PR TITLE
Make XCBProtocol_13_0 compile

### DIFF
--- a/Sources/XCBProtocol_13_0/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
+++ b/Sources/XCBProtocol_13_0/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
@@ -32,7 +32,7 @@ extension BuildOperationDiagnosticLocation: DecodableRPCPayload {
             
         case 2:
             let sourceRangeArgs = try args.parseArray(indexPath: indexPath + IndexPath(index: 1))
-            self = .sourceRanges(try targetArgs.parseStringArray(indexPath: indexPath + IndexPath(indexes: [1, 0])))
+            self = .sourceRanges(try sourceRangeArgs.parseStringArray(indexPath: indexPath + IndexPath(indexes: [1, 0])))
             
         default:
             throw RPCPayloadDecodingError.incorrectValueType(indexPath: indexPath + IndexPath(index: 0), expectedType: Self.self)


### PR DESCRIPTION
In my last PR: https://github.com/target/XCBBuildServiceProxy/pull/14

I renamed stuff too quickly and didn't check if it compiled. Now it does. Apologies!