### PR TITLE
use_top_level_targets_for_symlinks and macos_cpus configs

### DIFF
--- a/Examples/.bazelrc
+++ b/Examples/.bazelrc
@@ -1,0 +1,2 @@
+build --use_top_level_targets_for_symlinks
+build --macos_cpus=arm64,x86_64


### PR DESCRIPTION
This changes adds `use_top_level_targets_for_symlinks` so `bazel-bin` symlink points to the top level output directory:

<img width="985" alt="Captura de Pantalla 2021-10-22 a la(s) 14 33 07" src="https://user-images.githubusercontent.com/6267487/138512806-0c3c2a65-8f5d-4a4f-9730-962143cc1774.png">

Adds `macos_cpus=arm64,x86_64` in order to generate a fat binary that can run in Apple Silicon and Intel computers, this is helpful in case it should be distributed instead of being compiled in each dev computer:

```
➜ lipo -info bazel-bin/BazelXCBBuildService/BazelXCBBuildService                                                                                                
Architectures in the fat file: bazel-bin/BazelXCBBuildService/BazelXCBBuildService are: x86_64 arm64 
```