### PR TITLE
Xcode 13.3 Beta 3 support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,3 +40,9 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+alias(
+    name = "XCBProtocol_13_3",
+    actual = "//Sources/XCBProtocol_13_3",
+    visibility = ["//visibility:public"],
+)
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
-          "version": "2.30.0"
+          "revision": "154f1d32366449dcccf6375a173adf4ed2a74429",
+          "version": "2.38.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
-    name: "BazelXCBBuildServiceProxy",
-    platforms: [.macOS(.v10_14)],
+    name: "XCBBuildServiceProxy",
+    platforms: [.macOS(.v11)],
     products: [
         .library(name: "XCBProtocol", targets: ["XCBProtocol"]),
         .library(name: "XCBProtocol_11_3", targets: ["XCBProtocol_11_3"]),
@@ -35,9 +35,9 @@ let package = Package(
         .target(
             name: "XCBProtocol",
             dependencies: [
-                "Logging",
+                .product(name: "Logging", package: "swift-log"),
                 "MessagePack",
-                "NIO",
+                .product(name: "NIO", package: "swift-nio"),
             ],
             exclude: [
                 "BUILD.bazel"
@@ -96,8 +96,8 @@ let package = Package(
         .target(
             name: "XCBBuildServiceProxy",
             dependencies: [
-                "Logging",
-                "NIO",
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
                 "XCBProtocol",
             ],
             exclude: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "XCBProtocol_12_0", targets: ["XCBProtocol_12_0"]),
         .library(name: "XCBProtocol_12_5", targets: ["XCBProtocol_12_5"]),
         .library(name: "XCBProtocol_13_0", targets: ["XCBProtocol_13_0"]),
+        .library(name: "XCBProtocol_13_3", targets: ["XCBProtocol_13_3"]),
         .library(name: "XCBBuildServiceProxy", targets: ["XCBBuildServiceProxy"]),
     ],
     dependencies: [
@@ -30,7 +31,10 @@ let package = Package(
         ),
         .testTarget(
             name: "MessagePackTests",
-            dependencies: ["MessagePack"]
+            dependencies: ["MessagePack"],
+            exclude: [
+                "BUILD.bazel"
+            ]
         ),
         .target(
             name: "XCBProtocol",
@@ -85,6 +89,16 @@ let package = Package(
         ),
         .target(
             name: "XCBProtocol_13_0",
+            dependencies: [
+                "MessagePack",
+                "XCBProtocol",
+            ],
+            exclude: [
+                "BUILD.bazel"
+            ]
+        ),
+        .target(
+            name: "XCBProtocol_13_3",
             dependencies: [
                 "MessagePack",
                 "XCBProtocol",

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Make sure to update the versions used in the `repositories.bzl` file if you change them here
         .package(url: "https://github.com/apple/swift-log", .exact("1.4.2")),
-        .package(url: "https://github.com/apple/swift-nio", .exact("2.30.0")),
+        .package(url: "https://github.com/apple/swift-nio", .exact("2.38.0")),
     ],
     targets: [
         .target(

--- a/Sources/XCBBuildServiceProxy/Hybrid/HybridRPCRequestHandler.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/HybridRPCRequestHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Logging
 import NIO
+import os
 import XCBProtocol
 
 // swiftlint:disable opening_brace
@@ -40,7 +41,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
         // Here we are receiving a request from Xcode
         let request = unwrapInboundIn(data)
         
-        logger.debug("Received RPCRequest from Xcode: \(request)")
+        os_log("Received RPCRequest from Xcode: \(request)")
         
         // Start the proxied XCBBuildService if needed
         if let xcodePath = request.payload.createSessionXcodePath {
@@ -73,12 +74,12 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
         
         // Return a result for `sendRequest()`
         if let promise = responsePromises.removeValue(forKey: response.channel) {
-            logger.debug("Received RPCResponse from XCBBuildService: \(response)")
+            os_log("Received RPCResponse from XCBBuildService: \(response)")
             promise.succeed(response)
         } else {
             // Unknown channel, because of event stream or forwarded request
             // Just forward it back to Xcode
-            logger.debug("Received RPCResponse from XCBBuildService and sending to Xcode: \(response)")
+            os_log("Received RPCResponse from XCBBuildService and sending to Xcode: \(response)")
             context.writeAndFlush(data, promise: promise)
         }
     }
@@ -88,7 +89,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
             responsePromises[request.channel] = promise
         }
         
-        logger.debug("Sending RPCRequest to XCBBuildService: \(request)")
+        os_log("Sending RPCRequest to XCBBuildService: \(request)")
         
         xcbBuildService.channel.writeAndFlush(request, promise: nil)
     }
@@ -102,7 +103,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
     }
     
     private func sendResponse(_ response: Response, context: ChannelHandlerContext) {
-        logger.debug("Sending RPCResponse to Xcode: \(response)")
+        os_log("Sending RPCResponse to Xcode: \(response)")
         context.writeAndFlush(wrapOutboundOut(response), promise: nil)
     }
 }

--- a/Sources/XCBBuildServiceProxy/Hybrid/HybridRPCRequestHandler.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/HybridRPCRequestHandler.swift
@@ -41,7 +41,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
         // Here we are receiving a request from Xcode
         let request = unwrapInboundIn(data)
         
-        os_log("Received RPCRequest from Xcode: \(request)")
+        os_log(.debug, "Received RPCRequest from Xcode: \(request)")
         
         // Start the proxied XCBBuildService if needed
         if let xcodePath = request.payload.createSessionXcodePath {
@@ -74,12 +74,12 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
         
         // Return a result for `sendRequest()`
         if let promise = responsePromises.removeValue(forKey: response.channel) {
-            os_log("Received RPCResponse from XCBBuildService: \(response)")
+            os_log(.debug, "Received RPCResponse from XCBBuildService: \(response)")
             promise.succeed(response)
         } else {
             // Unknown channel, because of event stream or forwarded request
             // Just forward it back to Xcode
-            os_log("Received RPCResponse from XCBBuildService and sending to Xcode: \(response)")
+            os_log(.debug, "Received RPCResponse from XCBBuildService and sending to Xcode: \(response)")
             context.writeAndFlush(data, promise: promise)
         }
     }
@@ -89,7 +89,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
             responsePromises[request.channel] = promise
         }
         
-        os_log("Sending RPCRequest to XCBBuildService: \(request)")
+        os_log(.debug, "Sending RPCRequest to XCBBuildService: \(request)")
         
         xcbBuildService.channel.writeAndFlush(request, promise: nil)
     }
@@ -103,7 +103,7 @@ final class HybridRPCRequestHandler<RequestHandler: HybridXCBBuildServiceRequest
     }
     
     private func sendResponse(_ response: Response, context: ChannelHandlerContext) {
-        os_log("Sending RPCResponse to Xcode: \(response)")
+        os_log(.debug, "Sending RPCResponse to Xcode: \(response)")
         context.writeAndFlush(wrapOutboundOut(response), promise: nil)
     }
 }

--- a/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildService.swift
@@ -45,7 +45,7 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
     public func start() throws -> Channel {
         let channel = try bootstrap.withPipes(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO).wait()
         
-        os_log("\(self.name) started and listening on STDIN")
+        os_log(.info, "\(self.name) started and listening on STDIN")
         
         return channel
     }
@@ -54,9 +54,9 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
         do {
             try group.syncShutdownGracefully()
         } catch {
-            os_log("Error shutting down: \(error.localizedDescription)")
+            os_log(.error, "Error shutting down: \(error.localizedDescription)")
             exit(0)
         }
-        os_log("\(self.name) stopped")
+        os_log(.info, "\(self.name) stopped")
     }
 }

--- a/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIO
+import os
 import XCBProtocol
 
 public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRequestHandler> {
@@ -44,7 +45,7 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
     public func start() throws -> Channel {
         let channel = try bootstrap.withPipes(inputDescriptor: STDIN_FILENO, outputDescriptor: STDOUT_FILENO).wait()
         
-        logger.info("\(name) started and listening on STDIN")
+        os_log("\(self.name) started and listening on STDIN")
         
         return channel
     }
@@ -53,9 +54,9 @@ public final class HybridXCBBuildService<RequestHandler: HybridXCBBuildServiceRe
         do {
             try group.syncShutdownGracefully()
         } catch {
-            logger.error("Error shutting down: \(error)")
+            os_log("Error shutting down: \(error.localizedDescription)")
             exit(0)
         }
-        logger.info("\(name) stopped")
+        os_log("\(self.name) stopped")
     }
 }

--- a/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildServiceRequestHandler.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/HybridXCBBuildServiceRequestHandler.swift
@@ -1,5 +1,6 @@
 import Logging
 import NIO
+import os
 import XCBProtocol
 
 // swiftformat:disable braces
@@ -81,12 +82,11 @@ public final class HybridXCBBuildServiceRequestHandlerContext<RequestPayload, Re
     }
     
     public func sendErrorResponse(
-        _ messageClosure: @autoclosure () -> Logger.Message,
+        _ messageClosure: @autoclosure () -> String,
         request: Request,
         file: String = #file, function: String = #function, line: UInt = #line
     ) {
         let message = messageClosure()
-        logger.error(message, file: file, function: function, line: line)
         sendResponseMessage(.errorResponse(message.description), channel: request.channel)
     }
 }

--- a/Sources/XCBBuildServiceProxy/Hybrid/XCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/XCBBuildService.swift
@@ -43,12 +43,12 @@ final class XCBBuildService {
         guard !process.isRunning else {
             if process.launchPath != processPath {
                 let launchPath = process.launchPath ?? ""
-                os_log("XCBBuildService start request for “\(processPath)” but it’s already running at “\(launchPath)”")
+                os_log(.error, "XCBBuildService start request for “\(processPath)” but it’s already running at “\(launchPath)”")
             }
             return
         }
         
-        os_log("Starting XCBBuildService at “\(processPath)”")
+        os_log(.info, "Starting XCBBuildService at “\(processPath)”")
         
         process.launchPath = processPath
         process.launch()
@@ -103,15 +103,15 @@ final class XCBBuildServiceBootstrap<RequestPayload, ResponsePayload> where
             }
             
             if let output = String(data: data, encoding: .utf8) {
-                os_log("XCBBuildService stderr: \(output)")
+                os_log(.info, "XCBBuildService stderr: \(output)")
             }
         }
         
         process.terminationHandler = { process in
-            os_log("XCBBuildService exited with status code: \(process.terminationStatus)")
+            os_log(.info, "XCBBuildService exited with status code: \(process.terminationStatus)")
         }
         
-        os_log("Prepping XCBBuildService")
+        os_log(.info, "Prepping XCBBuildService")
         
         let channelFuture = bootstrap.withPipes(
             inputDescriptor: stdout.fileHandleForReading.fileDescriptor,
@@ -126,7 +126,7 @@ final class XCBBuildServiceBootstrap<RequestPayload, ResponsePayload> where
             
         channelFuture
             .whenSuccess { _ in
-                os_log("XCBBuildService prepped")
+                os_log(.info, "XCBBuildService prepped")
             }
         
         return channelFuture.map { XCBBuildService(process: process, channel: $0) }

--- a/Sources/XCBBuildServiceProxy/Hybrid/XCBBuildService.swift
+++ b/Sources/XCBBuildServiceProxy/Hybrid/XCBBuildService.swift
@@ -97,7 +97,7 @@ final class XCBBuildServiceBootstrap<RequestPayload, ResponsePayload> where
         stderr.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             guard !data.isEmpty else {
-                os_log("Received XCBBuildService standard error EOF")
+                os_log(.debug, "Received XCBBuildService standard error EOF")
                 stderr.fileHandleForReading.readabilityHandler = nil
                 return
             }

--- a/Sources/XCBProtocol/RPC/RPCPacket.swift
+++ b/Sources/XCBProtocol/RPC/RPCPacket.swift
@@ -40,7 +40,7 @@ public class RPCPacketCodec: ByteToMessageDecoder, MessageToByteEncoder {
     
     public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
         if let packet = try findNextPacket(buffer: &buffer) {
-            os_log("[\(self.label)] Decoded RPCPacket: \(packet)")
+            os_log(.debug, "[\(self.label)] Decoded RPCPacket: \(packet)")
             context.fireChannelRead(wrapInboundOut(packet))
             return .continue
         } else {
@@ -59,7 +59,7 @@ public class RPCPacketCodec: ByteToMessageDecoder, MessageToByteEncoder {
         // Reset header state since we have read the full packet now
         decodedHeader = nil
         
-        os_log("[\(self.label)] Decoded RPCPacket payload: \(payload)")
+        os_log(.debug, "[\(self.label)] Decoded RPCPacket payload: \(payload)")
         
         let body = try MessagePackValue.unpackAll(Data(payload))
         
@@ -88,7 +88,7 @@ public class RPCPacketCodec: ByteToMessageDecoder, MessageToByteEncoder {
     }
     
     public func encode(data packet: RPCPacket, out: inout ByteBuffer) throws {
-        os_log("[\(self.label)] Encoding RPCPacket: \(packet)")
+        os_log(.debug, "[\(self.label)] Encoding RPCPacket: \(packet)")
         
         let body = packet.body.reduce(into: Data()) { body, element in body.append(element.pack()) }
         

--- a/Sources/XCBProtocol/RPC/RPCRequest.swift
+++ b/Sources/XCBProtocol/RPC/RPCRequest.swift
@@ -26,7 +26,7 @@ public final class RPCRequestDecoder<Payload: RequestPayload>: ChannelInboundHan
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let request = RPCRequest<Payload>(unwrapInboundIn(data))
         
-        os_log("RPCRequest decoded: \(request)")
+        os_log(.debug, "RPCRequest decoded: \(request)")
         
         context.fireChannelRead(wrapInboundOut(request))
     }

--- a/Sources/XCBProtocol/RPC/RPCRequest.swift
+++ b/Sources/XCBProtocol/RPC/RPCRequest.swift
@@ -39,7 +39,7 @@ extension RPCRequest {
             payload = try packet.body.parseObject(indexPath: IndexPath())
         } catch {
             let errorStr = "\(error)"
-            os_log("Failed parsing RequestPayload received from Xcode: \(errorStr)\nValues: \(packet.body)")
+            os_log(.error, "Failed parsing RequestPayload received from Xcode: \(errorStr)\nValues: \(packet.body)")
             
             payload = .unknownRequest(values: packet.body)
         }

--- a/Sources/XCBProtocol/RPC/RPCResponse.swift
+++ b/Sources/XCBProtocol/RPC/RPCResponse.swift
@@ -42,7 +42,7 @@ public final class RPCResponseDecoder<Payload: ResponsePayload>: ChannelInboundH
         let packet = unwrapInboundIn(data)
         let response = RPCResponse<Payload>(packet)
         
-        os_log("RPCResponse decoded: \(response)")
+        os_log(.debug, "RPCResponse decoded: \(response)")
         
         context.fireChannelRead(wrapInboundOut(response))
     }

--- a/Sources/XCBProtocol/RPC/RPCResponse.swift
+++ b/Sources/XCBProtocol/RPC/RPCResponse.swift
@@ -55,7 +55,7 @@ extension RPCResponse {
             payload = try packet.body.parseObject(indexPath: IndexPath())
         } catch {
             let errorStr = "\(error)"
-            os_log("Failed parsing ResponsePayload received from XCBBuildService: \(errorStr)\nValues: \(packet.body)")
+            os_log(.error, "Failed parsing ResponsePayload received from XCBBuildService: \(errorStr)\nValues: \(packet.body)")
             
             payload = .unknownResponse(values: packet.body)
         }

--- a/Sources/XCBProtocol/RPC/RPCResponse.swift
+++ b/Sources/XCBProtocol/RPC/RPCResponse.swift
@@ -1,9 +1,12 @@
 import Foundation
 import MessagePack
 import NIO
+import os
 
 /// An RPC response sent to Xcode.
-public struct RPCResponse<Payload: ResponsePayload> {
+public struct RPCResponse<Payload: ResponsePayload>: CustomStringConvertible {
+    public var description: String { "Channel: \(channel) - Payload: \(payload) "}
+    
     public let channel: UInt64
     public let payload: Payload
     
@@ -39,7 +42,7 @@ public final class RPCResponseDecoder<Payload: ResponsePayload>: ChannelInboundH
         let packet = unwrapInboundIn(data)
         let response = RPCResponse<Payload>(packet)
         
-        logger.trace("RPCResponse decoded: \(response)")
+        os_log("RPCResponse decoded: \(response)")
         
         context.fireChannelRead(wrapInboundOut(response))
     }
@@ -51,7 +54,8 @@ extension RPCResponse {
         do {
             payload = try packet.body.parseObject(indexPath: IndexPath())
         } catch {
-            logger.error("Failed parsing ResponsePayload received from XCBBuildService: \(error)\nValues: \(packet.body)")
+            let errorStr = "\(error)"
+            os_log("Failed parsing ResponsePayload received from XCBBuildService: \(errorStr)\nValues: \(packet.body)")
             
             payload = .unknownResponse(values: packet.body)
         }

--- a/Sources/XCBProtocol_13_3/BUILD.bazel
+++ b/Sources/XCBProtocol_13_3/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "XCBProtocol_13_3",
+    srcs = glob(["**/*.swift"]),
+    module_name = "XCBProtocol_13_3",
+    deps = [
+        "//Sources/MessagePack",
+        "//Sources/XCBProtocol",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationEnded.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationEnded.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationEnded.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationPreparationCompleted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationPreparationCompleted.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationPreparationCompleted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationProgressUpdated.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationProgressUpdated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationProgressUpdated.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationReportPathMap.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationReportPathMap.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationReportPathMap.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationStarted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationStarted.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationStarted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/BuildOperationStatus.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/BuildOperationStatus.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build Operation/BuildOperationStatus.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticComponent.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Diagnostic/BuildOperationDiagnosticEmitted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Diagnostic/BuildOperationDiagnosticKind.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Diagnostic/BuildOperationDiagnosticLocation.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MessagePack
+import XCBProtocol
+
+// Probably named wrong
+public enum BuildOperationDiagnosticLocation {
+    case alternativeMessage(String) // Might be named wrong. Always empty so far.
+    case locationContext(file: String, line: Int64, column: Int64)
+}
+
+// MARK: - Decoding
+
+extension BuildOperationDiagnosticLocation: DecodableRPCPayload {
+    public init(args: [MessagePackValue], indexPath: IndexPath) throws {
+        guard args.count == 2 else { throw RPCPayloadDecodingError.invalidCount(args.count, indexPath: indexPath) }
+        
+        let rawValue = try args.parseInt64(indexPath: indexPath + IndexPath(index: 0))
+        
+        switch rawValue {
+        case 0:
+            self = .alternativeMessage(try args.parseString(indexPath: indexPath + IndexPath(index: 1)))
+            
+        case 1:
+            let locationArgs = try args.parseArray(indexPath: indexPath + IndexPath(index: 1))
+            
+            self = .locationContext(
+                file: try locationArgs.parseString(indexPath: indexPath + IndexPath(indexes: [1, 0])),
+                line: try locationArgs.parseInt64(indexPath: indexPath + IndexPath(indexes: [1, 1])),
+                column: try locationArgs.parseInt64(indexPath: indexPath + IndexPath(indexes: [1, 2]))
+            )
+            
+        default:
+            throw RPCPayloadDecodingError.incorrectValueType(indexPath: indexPath + IndexPath(index: 0), expectedType: Self.self)
+        }
+    }
+}
+
+// MARK: - Encoding
+
+extension BuildOperationDiagnosticLocation: EncodableRPCPayload {
+    public func encode() -> [MessagePackValue] {
+        switch self {
+        case let .alternativeMessage(message):
+            return [
+                .int64(0),
+                .string(message),
+            ]
+            
+        case let .locationContext(file, line, column):
+            return [
+                .int64(1),
+                .array([
+                    .string(file),
+                    .array([
+                        .int64(0),
+                        .array([
+                            .int64(line),
+                            .int64(column),
+                        ])
+                    ]),
+                ]),
+            ]
+        }
+    }
+}

--- a/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetEnded.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetEnded.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetEnded.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetInfo.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetInfo.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Target/BuildOperationTargetInfo.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetProjectInfo.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetProjectInfo.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Target/BuildOperationTargetProjectInfo.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetStarted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetStarted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Target/BuildOperationTargetStarted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetUpToDate.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Target/BuildOperationTargetUpToDate.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Target/BuildOperationTargetUpToDate.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationConsoleOutputEmitted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskEnded.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskEnded.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Task/BuildOperationTaskEnded.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskMetrics.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskMetrics.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_11_4/Build Operation/Task/BuildOperationTaskMetrics.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskStarted.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskStarted.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_13_0/Build Operation/Task/BuildOperationTaskStarted.swift

--- a/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskUpToDate.swift
+++ b/Sources/XCBProtocol_13_3/Build Operation/Task/BuildOperationTaskUpToDate.swift
@@ -1,0 +1,1 @@
+../../../XCBProtocol_12_5/Build Operation/Task/BuildOperationTaskUpToDate.swift

--- a/Sources/XCBProtocol_13_3/Build/ArenaInfo.swift
+++ b/Sources/XCBProtocol_13_3/Build/ArenaInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/ArenaInfo.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildCancelRequest.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildCancelRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildCancelRequest.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildCommand.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildCommand.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/BuildCommand.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildCreated.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildCreated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildCreated.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildParameters.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildParameters.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/BuildParameters.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildPlatform.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildPlatform.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/BuildPlatform.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildRequest.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/BuildRequest.swift

--- a/Sources/XCBProtocol_13_3/Build/BuildStartRequest.swift
+++ b/Sources/XCBProtocol_13_3/Build/BuildStartRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Build/BuildStartRequest.swift

--- a/Sources/XCBProtocol_13_3/Build/ConfiguredTarget.swift
+++ b/Sources/XCBProtocol_13_3/Build/ConfiguredTarget.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/ConfiguredTarget.swift

--- a/Sources/XCBProtocol_13_3/Build/CreateBuildRequest.swift
+++ b/Sources/XCBProtocol_13_3/Build/CreateBuildRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/CreateBuildRequest.swift

--- a/Sources/XCBProtocol_13_3/Build/RunDestinationInfo.swift
+++ b/Sources/XCBProtocol_13_3/Build/RunDestinationInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/RunDestinationInfo.swift

--- a/Sources/XCBProtocol_13_3/Build/SchemeCommand.swift
+++ b/Sources/XCBProtocol_13_3/Build/SchemeCommand.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/SchemeCommand.swift

--- a/Sources/XCBProtocol_13_3/Build/SettingsOverrides.swift
+++ b/Sources/XCBProtocol_13_3/Build/SettingsOverrides.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Build/SettingsOverrides.swift

--- a/Sources/XCBProtocol_13_3/Core/BoolResponse.swift
+++ b/Sources/XCBProtocol_13_3/Core/BoolResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/BoolResponse.swift

--- a/Sources/XCBProtocol_13_3/Core/ErrorResponse.swift
+++ b/Sources/XCBProtocol_13_3/Core/ErrorResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/ErrorResponse.swift

--- a/Sources/XCBProtocol_13_3/Core/PingResponse.swift
+++ b/Sources/XCBProtocol_13_3/Core/PingResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/PingResponse.swift

--- a/Sources/XCBProtocol_13_3/Core/StringResponse.swift
+++ b/Sources/XCBProtocol_13_3/Core/StringResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Core/StringResponse.swift

--- a/Sources/XCBProtocol_13_3/Indexing Info/IndexingInfoRequest.swift
+++ b/Sources/XCBProtocol_13_3/Indexing Info/IndexingInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Indexing Info/IndexingInfoRequest.swift

--- a/Sources/XCBProtocol_13_3/Indexing Info/IndexingInfoResponse.swift
+++ b/Sources/XCBProtocol_13_3/Indexing Info/IndexingInfoResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Indexing Info/IndexingInfoResponse.swift

--- a/Sources/XCBProtocol_13_3/Planning Operation/PlanningOperationDidFinish.swift
+++ b/Sources/XCBProtocol_13_3/Planning Operation/PlanningOperationDidFinish.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Planning Operation/PlanningOperationDidFinish.swift

--- a/Sources/XCBProtocol_13_3/Planning Operation/PlanningOperationWillStart.swift
+++ b/Sources/XCBProtocol_13_3/Planning Operation/PlanningOperationWillStart.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Planning Operation/PlanningOperationWillStart.swift

--- a/Sources/XCBProtocol_13_3/Preview Info/PreviewInfo.swift
+++ b/Sources/XCBProtocol_13_3/Preview Info/PreviewInfo.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Preview Info/PreviewInfo.swift

--- a/Sources/XCBProtocol_13_3/Preview Info/PreviewInfoRequest.swift
+++ b/Sources/XCBProtocol_13_3/Preview Info/PreviewInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_13_0/Preview Info/PreviewInfoRequest.swift

--- a/Sources/XCBProtocol_13_3/Preview Info/PreviewInfoResponse.swift
+++ b/Sources/XCBProtocol_13_3/Preview Info/PreviewInfoResponse.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Preview Info/PreviewInfoResponse.swift

--- a/Sources/XCBProtocol_13_3/RequestPayload.swift
+++ b/Sources/XCBProtocol_13_3/RequestPayload.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MessagePack
+import XCBProtocol
+
+public enum RequestPayload {
+    case createSession(CreateSessionRequest)
+    case transferSessionPIFRequest(TransferSessionPIFRequest)
+    case setSessionSystemInfo(SetSessionSystemInfoRequest)
+    case setSessionUserInfo(SetSessionUserInfoRequest)
+    
+    case createBuildRequest(CreateBuildRequest)
+    case buildStartRequest(BuildStartRequest)
+    case buildCancelRequest(BuildCancelRequest)
+    
+    case indexingInfoRequest(IndexingInfoRequest)
+    
+    case previewInfoRequest(PreviewInfoRequest)
+    
+    case unknownRequest(UnknownRequest)
+}
+
+public struct UnknownRequest {
+    public let values: [MessagePackValue]
+}
+
+// MARK: - Encoding
+
+extension RequestPayload: XCBProtocol.RequestPayload {
+    public static func unknownRequest(values: [MessagePackValue]) -> Self {
+        return .unknownRequest(.init(values: values))
+    }
+    
+    public init(values: [MessagePackValue], indexPath: IndexPath) throws {
+        let name = try values.parseString(indexPath: indexPath + IndexPath(index: 0))
+        let bodyIndexPath = indexPath + IndexPath(index: 1)
+        
+        switch name {
+        case "CREATE_SESSION": self = .createSession(try values.parseObject(indexPath: bodyIndexPath))
+        case "TRANSFER_SESSION_PIF_REQUEST": self = .transferSessionPIFRequest(try values.parseObject(indexPath: bodyIndexPath))
+        case "SET_SESSION_SYSTEM_INFO": self = .setSessionSystemInfo(try values.parseObject(indexPath: indexPath))
+        case "SET_SESSION_USER_INFO":
+            let data = try values.parseBinary(indexPath: bodyIndexPath)
+            self = .setSessionUserInfo(try JSONDecoder().decode(SetSessionUserInfoRequest.self, from: data))
+            
+        case "CREATE_BUILD":
+            let data = try values.parseBinary(indexPath: bodyIndexPath)
+            self = .createBuildRequest(try JSONDecoder().decode(CreateBuildRequest.self, from: data))
+            
+        case "BUILD_START": self = .buildStartRequest(try values.parseObject(indexPath: bodyIndexPath))
+        case "BUILD_CANCEL": self = .buildCancelRequest(try values.parseObject(indexPath: bodyIndexPath))
+            
+        case "INDEXING_INFO_REQUESTED":
+            let data = try values.parseBinary(indexPath: bodyIndexPath)
+            self = .indexingInfoRequest(try JSONDecoder().decode(IndexingInfoRequest.self, from: data))
+            
+        case "PREVIEW_INFO_REQUESTED":
+            let data = try values.parseBinary(indexPath: bodyIndexPath)
+            self = .previewInfoRequest(try JSONDecoder().decode(PreviewInfoRequest.self, from: data))
+            
+        default: self = .unknownRequest(.init(values: values))
+        }
+    }
+    
+    public var createSessionXcodePath: String? {
+        switch self {
+        case .createSession(let message): return message.appPath
+        default: return nil
+        }
+    }
+}

--- a/Sources/XCBProtocol_13_3/ResponsePayload.swift
+++ b/Sources/XCBProtocol_13_3/ResponsePayload.swift
@@ -1,0 +1,1 @@
+../XCBProtocol_13_0/ResponsePayload.swift

--- a/Sources/XCBProtocol_13_3/Session/CreateSessionRequest.swift
+++ b/Sources/XCBProtocol_13_3/Session/CreateSessionRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/CreateSessionRequest.swift

--- a/Sources/XCBProtocol_13_3/Session/SessionCreated.swift
+++ b/Sources/XCBProtocol_13_3/Session/SessionCreated.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_12_0/Session/SessionCreated.swift

--- a/Sources/XCBProtocol_13_3/Session/SetSessionSystemInfoRequest.swift
+++ b/Sources/XCBProtocol_13_3/Session/SetSessionSystemInfoRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/SetSessionSystemInfoRequest.swift

--- a/Sources/XCBProtocol_13_3/Session/SetSessionUserInfoRequest.swift
+++ b/Sources/XCBProtocol_13_3/Session/SetSessionUserInfoRequest.swift
@@ -1,0 +1,15 @@
+import Foundation
+import MessagePack
+import XCBProtocol
+
+public struct SetSessionUserInfoRequest: Decodable {
+    public let sessionHandle: String
+    public let user: String
+    public let group: String
+    public let uid: Int64
+    public let gid: Int64
+    public let home: String
+    public let xcodeProcessEnvironment: [String: String]?
+    public let buildSystemEnvironment: [String: String]
+    public let usePerConfigurationBuildDirectories: Bool?
+}

--- a/Sources/XCBProtocol_13_3/Session/TransferSessionPIFRequest.swift
+++ b/Sources/XCBProtocol_13_3/Session/TransferSessionPIFRequest.swift
@@ -1,0 +1,1 @@
+../../XCBProtocol_11_4/Session/TransferSessionPIFRequest.swift


### PR DESCRIPTION
This adds support for Xcode 13.3 Beta 3. I'll update it next week if there are any required changes with the release candidate. (I'm assuming the new Xcode is going to drop with the Apple event).

**Changes of note:**
* Needed to update swift-nio for the new version of swift/standard libraries
* The Swift Logging functionality was blocking it from working - not sure exactly why, but I replaced it with `os_log` so we can still get the diagnostic data. This required me to update the supported `MacOS` version to `11`, which required some format changes in `Package.swift` (namely `.product`)

After debugging the logging issue, the only protocol changes were:
* `SET_SESSION_USER_INFO` is sent as JSON now, which required a `RequestPayload` update
* `BuildOperationDiagnosticLocation` format change in the message we send to Xcode. There's an extra `int` that I only saw as `0`, and the `line/column` got packaged into an array.